### PR TITLE
Feat/fred get release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **FRED provider**: **`FredMacroeconomicProvider.get_release_dates`** resolves the parent release for a **FRED** series (`/series/release`), loads **`/release/dates`** with **`limit`** and **`sort_order`**, and returns **UTC** **`datetime`** values; handles **`releases`** or singular **`release`** payloads. Unit tests cover the two-step flow, empty release metadata, and missing API key.
 - **Library — `financial_literacy` on analyze requests & stable imports**: Optional **`financial_literacy`** on **`AnalyzeInstrumentRequest`** / **`AnalyzeMarketRequest`** overrides the attached profile tier; **`copinance_os`** re-exports **`AnalyzeInstrumentRequest`**, **`AnalyzeMarketRequest`**, **`AnalyzeMode`**, **`RunJobResult`**, **`AnalysisReport`**, **`AnalysisProfile`**, and **`FinancialLiteracy`** for a single import path. Developer guide **`financial-literacy.mdx`** (nav **Financial literacy (clients)**); **Using as a Library** documents request-level literacy, precedence, and the intermediate default.
 - **CLI — async commands**: Transient Rich **dots** spinner on **stderr** while **`async_command`** runs in an interactive terminal; suppressed for **`--json`** (machine-readable stdout) and non-TTY environments.
 - **Transparency contract — options positioning + Greeks methodology (breaking)**: Methodology is now standardized through shared **`AnalysisMethodology`** / **`MethodologySpec`** value objects. `OptionsPositioningResult`, `AnalysisReport`, market-regime outputs, and backtest outputs all use the same structured envelope.
@@ -86,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FRED provider typing guard**: Added an explicit terminal `RuntimeError` in `FredMacroeconomicProvider._get_with_retry` to satisfy strict mypy return-path analysis after retry-loop hardening.
+- **FRED release dates resilience**: `FredMacroeconomicProvider.get_release_dates` now retries transient transport failures plus HTTP `429`/`5xx` responses with bounded backoff+jitter before surfacing errors; added focused unit tests for retry-success and retry-exhaustion paths.
 - **Docs — library literacy example**: Replaced smart quotes in the **Using as a Library** Python snippet with ASCII string literals so the sample is valid Python.
 - **yfinance quotes**: Intraday quote `volume` prefers a whole-session sum from 1m history when available (latest bar volume is often zero); `info` volume fields use safe integer coercion with fallbacks (`regularMarketVolume`, `volume`, `averageVolume`, `averageDailyVolume3Month`).
 - **Options positioning tests**: Regenerated `tests/fixtures/options_positioning/toy_near.json` to match updated methodology reference metadata and keep golden-fixture regression assertions in sync.

--- a/src/copinance_os/data/providers/fred.py
+++ b/src/copinance_os/data/providers/fred.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import random
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 import structlog
@@ -32,6 +33,9 @@ class FredMacroeconomicProvider(MacroeconomicDataProvider):
         self._rate_limit_delay = rate_limit_delay
         self._timeout_seconds = timeout_seconds
         self._client: httpx.AsyncClient | None = None
+        self._max_retry_attempts = 3
+        self._retry_base_delay_seconds = 0.25
+        self._retry_max_delay_seconds = 2.0
 
     @override
     def get_provider_name(self) -> str:
@@ -45,6 +49,57 @@ class FredMacroeconomicProvider(MacroeconomicDataProvider):
                 follow_redirects=True,
             )
         return self._client
+
+    async def _get_with_retry(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any],
+    ) -> httpx.Response:
+        """Execute GET with bounded retries for transient transport failures."""
+        client = await self._get_client()
+        for attempt in range(1, self._max_retry_attempts + 1):
+            try:
+                response = await client.get(path, params=params)
+                is_transient_status = response.status_code == 429 or response.status_code >= 500
+                if is_transient_status and attempt < self._max_retry_attempts:
+                    backoff = min(
+                        self._retry_max_delay_seconds,
+                        self._retry_base_delay_seconds * (2 ** (attempt - 1)),
+                    )
+                    jitter = random.uniform(0.0, backoff * 0.2)
+                    delay = backoff + jitter
+                    logger.warning(
+                        "Transient FRED HTTP status; retrying request",
+                        path=path,
+                        attempt=attempt,
+                        max_attempts=self._max_retry_attempts,
+                        status_code=response.status_code,
+                        delay_seconds=round(delay, 3),
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                return response
+            except httpx.TransportError as exc:
+                if attempt >= self._max_retry_attempts:
+                    raise
+                backoff = min(
+                    self._retry_max_delay_seconds,
+                    self._retry_base_delay_seconds * (2 ** (attempt - 1)),
+                )
+                jitter = random.uniform(0.0, backoff * 0.2)
+                delay = backoff + jitter
+                logger.warning(
+                    "Transient FRED transport error; retrying request",
+                    path=path,
+                    attempt=attempt,
+                    max_attempts=self._max_retry_attempts,
+                    delay_seconds=round(delay, 3),
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                await asyncio.sleep(delay)
+        raise RuntimeError("FRED retry loop exhausted without response")
 
     @override
     async def is_available(self) -> bool:
@@ -128,6 +183,89 @@ class FredMacroeconomicProvider(MacroeconomicDataProvider):
             )
 
         return points
+
+    async def get_release_dates(
+        self,
+        series_id: str,
+        *,
+        limit: int = 1000,
+        sort_order: Literal["asc", "desc"] = "desc",
+    ) -> list[datetime]:
+        """Return scheduled release dates for the FRED release that contains ``series_id``.
+
+        Resolves the series' parent release via ``/series/release``, then fetches
+        ``/release/dates`` for that release. When FRED returns multiple releases
+        for one series, the first entry is used.
+
+        Args:
+            series_id: FRED series identifier (e.g. ``UNRATE``).
+            limit: Maximum number of dates to return (passed to the FRED API).
+            sort_order: ``asc`` or ``desc`` (newest first when ``desc``).
+
+        Returns:
+            Release dates as UTC midnight timestamps, ordered per ``sort_order``.
+        """
+        if not self._api_key:
+            raise RuntimeError("FRED API key not configured (set COPINANCEOS_FRED_API_KEY)")
+
+        base_params: dict[str, Any] = {
+            "api_key": self._api_key,
+            "file_type": "json",
+        }
+
+        await asyncio.sleep(self._rate_limit_delay)
+        rel_resp = await self._get_with_retry(
+            "/series/release",
+            params={**base_params, "series_id": series_id},
+        )
+        rel_resp.raise_for_status()
+        rel_payload = rel_resp.json()
+
+        releases_raw = rel_payload.get("releases")
+        if not isinstance(releases_raw, list) or not releases_raw:
+            single = rel_payload.get("release")
+            if isinstance(single, dict):
+                releases_raw = [single]
+            else:
+                return []
+
+        first = releases_raw[0]
+        if not isinstance(first, dict):
+            return []
+        release_id = first.get("id")
+        if release_id is None:
+            return []
+
+        await asyncio.sleep(self._rate_limit_delay)
+        dates_resp = await self._get_with_retry(
+            "/release/dates",
+            params={
+                **base_params,
+                "release_id": release_id,
+                "limit": limit,
+                "sort_order": sort_order,
+            },
+        )
+        dates_resp.raise_for_status()
+        dates_payload = dates_resp.json()
+
+        rows = dates_payload.get("release_dates")
+        if not isinstance(rows, list):
+            return []
+
+        out: list[datetime] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            date_str = row.get("date")
+            if not date_str or not isinstance(date_str, str):
+                continue
+            try:
+                out.append(datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC))
+            except ValueError:
+                continue
+
+        return out
 
     async def close(self) -> None:
         if self._client is not None:

--- a/tests/unit/copinance_os/data/providers/test_fred.py
+++ b/tests/unit/copinance_os/data/providers/test_fred.py
@@ -56,3 +56,231 @@ class TestFredMacroeconomicProvider:
                 datetime(2025, 1, 1, tzinfo=UTC),
                 datetime(2025, 1, 5, tzinfo=UTC),
             )
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_chains_series_release_and_release_dates(self) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                calls.append((path, dict(params)))
+                if path == "/series/release":
+                    payload = {"releases": [{"id": 82, "name": "Employment Situation"}]}
+                elif path == "/release/dates":
+                    payload = {
+                        "release_dates": [
+                            {"release_id": 82, "date": "2025-01-03"},
+                            {"release_id": 82, "date": "2025-01-10"},
+                        ]
+                    }
+                else:
+                    raise AssertionError(f"unexpected path {path}")
+                req = httpx.Request("GET", f"https://example.com{path}")
+                return httpx.Response(200, json=payload, request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+
+        dates = await provider.get_release_dates("UNRATE", limit=50)
+
+        assert calls[0][0] == "/series/release"
+        assert calls[0][1]["series_id"] == "UNRATE"
+        assert calls[1][0] == "/release/dates"
+        assert calls[1][1]["release_id"] == 82
+        assert calls[1][1]["limit"] == 50
+        assert calls[1][1]["sort_order"] == "desc"
+        assert dates == [
+            datetime(2025, 1, 3, tzinfo=UTC),
+            datetime(2025, 1, 10, tzinfo=UTC),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_accepts_singular_release_payload(self) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+
+        class DummyClient:
+            def __init__(self) -> None:
+                self._step = 0
+
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                self._step += 1
+                if path == "/series/release":
+                    payload = {"release": {"id": 10, "name": "GDP"}}
+                else:
+                    payload = {"release_dates": [{"release_id": 10, "date": "2024-06-01"}]}
+                req = httpx.Request("GET", f"https://example.com{path}")
+                return httpx.Response(200, json=payload, request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+
+        dates = await provider.get_release_dates("GNPCA")
+        assert dates == [datetime(2024, 6, 1, tzinfo=UTC)]
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_empty_when_no_release(self) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                payload: dict[str, object] = {"releases": []} if path == "/series/release" else {}
+                req = httpx.Request("GET", f"https://example.com{path}")
+                return httpx.Response(200, json=payload, request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+
+        dates = await provider.get_release_dates("UNKNOWN")
+        assert dates == []
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_requires_api_key(self) -> None:
+        provider = FredMacroeconomicProvider(api_key=None)
+        with pytest.raises(RuntimeError):
+            await provider.get_release_dates("UNRATE")
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_retries_transient_transport_error(self, monkeypatch) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+        provider._retry_base_delay_seconds = 0.0
+        provider._retry_max_delay_seconds = 0.0
+
+        attempts = {"series_release": 0}
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                if path == "/series/release":
+                    attempts["series_release"] += 1
+                    if attempts["series_release"] == 1:
+                        req = httpx.Request("GET", "https://example.com/series/release")
+                        raise httpx.ConnectError("transient network drop", request=req)
+                    payload = {"releases": [{"id": 50, "name": "Employment Situation"}]}
+                elif path == "/release/dates":
+                    payload = {
+                        "release_dates": [
+                            {"release_id": 50, "date": "2026-04-03"},
+                            {"release_id": 50, "date": "2026-03-06"},
+                        ]
+                    }
+                else:
+                    raise AssertionError(f"unexpected path {path}")
+                req = httpx.Request("GET", f"https://example.com{path}")
+                return httpx.Response(200, json=payload, request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+        monkeypatch.setattr("copinance_os.data.providers.fred.random.uniform", lambda _a, _b: 0.0)
+
+        dates = await provider.get_release_dates("UNRATE", limit=2)
+
+        assert attempts["series_release"] == 2
+        assert dates == [
+            datetime(2026, 4, 3, tzinfo=UTC),
+            datetime(2026, 3, 6, tzinfo=UTC),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_raises_after_retry_exhaustion(self, monkeypatch) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+        provider._retry_base_delay_seconds = 0.0
+        provider._retry_max_delay_seconds = 0.0
+        provider._max_retry_attempts = 2
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                req = httpx.Request("GET", f"https://example.com{path}")
+                raise httpx.RemoteProtocolError("Server disconnected", request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+        monkeypatch.setattr("copinance_os.data.providers.fred.random.uniform", lambda _a, _b: 0.0)
+
+        with pytest.raises(httpx.RemoteProtocolError):
+            await provider.get_release_dates("UNRATE")
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_retries_on_http_500_then_succeeds(self, monkeypatch) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+        provider._retry_base_delay_seconds = 0.0
+        provider._retry_max_delay_seconds = 0.0
+
+        attempts = {"series_release": 0}
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                req = httpx.Request("GET", f"https://example.com{path}")
+                if path == "/series/release":
+                    attempts["series_release"] += 1
+                    if attempts["series_release"] == 1:
+                        return httpx.Response(500, json={"error": "temporary outage"}, request=req)
+                    return httpx.Response(
+                        200,
+                        json={"releases": [{"id": 50, "name": "Employment Situation"}]},
+                        request=req,
+                    )
+                if path == "/release/dates":
+                    return httpx.Response(
+                        200,
+                        json={"release_dates": [{"release_id": 50, "date": "2026-04-03"}]},
+                        request=req,
+                    )
+                raise AssertionError(f"unexpected path {path}")
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+        monkeypatch.setattr("copinance_os.data.providers.fred.random.uniform", lambda _a, _b: 0.0)
+
+        dates = await provider.get_release_dates("UNRATE", limit=1)
+        assert attempts["series_release"] == 2
+        assert dates == [datetime(2026, 4, 3, tzinfo=UTC)]
+
+    @pytest.mark.asyncio
+    async def test_get_release_dates_raises_http_status_after_retry_exhaustion(
+        self, monkeypatch
+    ) -> None:
+        provider = FredMacroeconomicProvider(api_key="test-key", base_url="https://example.com")
+        provider._retry_base_delay_seconds = 0.0
+        provider._retry_max_delay_seconds = 0.0
+        provider._max_retry_attempts = 2
+
+        class DummyClient:
+            async def get(
+                self, path: str, params: dict, timeout: float | None = None
+            ) -> httpx.Response:
+                req = httpx.Request("GET", f"https://example.com{path}")
+                return httpx.Response(500, json={"error": "still down"}, request=req)
+
+        async def _dummy_get_client() -> DummyClient:  # type: ignore[override]
+            return DummyClient()
+
+        provider._get_client = _dummy_get_client  # type: ignore[method-assign]
+        monkeypatch.setattr("copinance_os.data.providers.fred.random.uniform", lambda _a, _b: 0.0)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await provider.get_release_dates("UNRATE")


### PR DESCRIPTION
# Improve FRED release-date resilience and test coverage

## Description

Harden FRED release-date retrieval against transient upstream/network failures.
This PR builds on the initial `get_release_dates` implementation by adding
bounded retries with jitter for transport errors and transient HTTP statuses
(`429`, `5xx`), then validates behavior with focused unit tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [x] 🧪 Test additions or updates
- [ ] 🔨 Build/config changes
- [ ] 🎨 Style/formatting changes

## Related Issues

Fixes #
Closes #
Related to #

## Changes Made

- Added `FredMacroeconomicProvider.get_release_dates` flow to resolve release
  metadata via `/series/release` and fetch schedule rows from
  `/release/dates` with `limit` and `sort_order`.
- Added `_get_with_retry()` in the FRED provider with capped exponential
  backoff + jitter for transient failures.
- Retry policy now covers both:
  - `httpx.TransportError` (e.g., `RemoteProtocolError`, connection drops)
  - HTTP `429` and all `5xx` responses
- Wired both release-date HTTP calls to use the retry helper.
- Expanded provider unit tests for:
  - transport retry then success
  - transport retry exhaustion
  - HTTP 500 retry then success
  - HTTP 500 retry exhaustion
- Updated `CHANGELOG.md` under `## [Unreleased] -> ### Fixed` to document the
  resilience improvement.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Tests cover both success and error cases
- [ ] Integration tests updated (if applicable)

### Test Commands
```bash
.venv/bin/python -m pytest tests/unit/copinance_os/data/providers/test_fred.py -q
```

## Code Quality

- [x] Code is formatted with `black`
- [x] Linting passes with `ruff`
- [x] Type checking passes with `mypy`
- [x] No new warnings or errors introduced

### Code Quality Commands
```bash
# Verified via repository pre-commit/test workflow on touched files
.venv/bin/python -m pytest tests/unit/copinance_os/data/providers/test_fred.py -q
```

## Documentation

- [ ] README updated (if applicable)
- [x] Docstrings added/updated for new functions/classes
- [ ] Architecture docs updated (if applicable)
- [x] CHANGELOG updated (for significant changes)
- [ ] API documentation updated (if applicable)

## Architecture Compliance

- [x] Follows clean architecture principles
- [x] Domain layer remains dependency-free
- [x] Proper dependency injection used
- [ ] Interfaces defined in domain/ports (if adding new functionality)
- [x] Implementation in appropriate infrastructure layer

## Screenshots/Examples

N/A (provider and unit-test changes only).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- This aligns with the `CHANGELOG.md` Unreleased entries for:
  - added `get_release_dates`
  - fixed resilience for transient FRED failures
- Follow-up option: apply the same retry wrapper to other FRED endpoints for
  consistency (`get_time_series`, `is_available`).

## Reviewer Notes

- Please focus on retry boundaries (which statuses are retried and when errors
  are surfaced) and test determinism around backoff/jitter behavior.
